### PR TITLE
Book API Routes and Controllers Part 2

### DIFF
--- a/server/controllers/booksApi.js
+++ b/server/controllers/booksApi.js
@@ -72,16 +72,19 @@ async function getAuthorsFromIds(authorIds, maxNumReqs) {
 
 //Route Controllers
 
-//get the top 10 daily trending books from OpenLibrary
+//Get featured books.
+//Get the top 10 daily trending books from OpenLibrary.
 const featured = async (req, res) => {
     try {
         let limit = 10;
 
         //API call for getting the trending books of the day
         let workUrl = `https://openlibrary.org/trending/daily.json?limit=${limit}`;
+
+        //Make request and get JSON object containing information
         let resultJson = await getJsonFromReq(workUrl);
 
-        //parse data into a useable form (Open Library ID, title, book cover link)
+        //parse data into a useable form (array of Open Library IDs, titles, book cover links)
         let featuredBooks = [];
         for (let i = 0; i < resultJson.works.length; i++) {
             let bookCover = "No cover provided.";
@@ -104,7 +107,8 @@ const featured = async (req, res) => {
     }
 }
 
-//Get information about the work at the specified Open Library ID (OLID). The ID MUST end with a 'W'.
+//Get information about the work at the specified Open Library ID (OLID).
+//The ID MUST end with a 'W'.
 const workInformation = async (req, res) => {
     try {
         let bookId = req.params.id;
@@ -112,7 +116,7 @@ const workInformation = async (req, res) => {
         //API call for getting the work's information
         let workUrl = `https://openlibrary.org/works/${bookId}.json`;
 
-        //parse data into JSON object
+        //Make request and get JSON object containing information
         let resultJson = await getJsonFromReq(workUrl);
 
         //parse data into a useable form (title, authors, first published date,
@@ -123,8 +127,6 @@ const workInformation = async (req, res) => {
                 authorIds.push(resultJson.authors[i].author.key);
             }
         }
-
-
         // get author information while only having 5 active requests at a time.
         let maxNumReqs = 5;
         let authors = "No author provided.";
@@ -170,7 +172,8 @@ const workInformation = async (req, res) => {
     }
 }
 
-//Get book information from a specified Open Library ID (OLID). The ID MUST end with an 'M'.
+//Get book information from a specified Open Library ID (OLID).
+//The ID MUST end with an 'M'.
 const bookInformation = async (req, res) => {
     try {
         let bookId = req.params.id;
@@ -178,9 +181,12 @@ const bookInformation = async (req, res) => {
         //API call for getting the work's information
         let workUrl = `https://openlibrary.org/books/${bookId}.json`;
 
-        //parse data into JSON object
+        //Make request and get JSON object containing information
         let resultJson = await getJsonFromReq(workUrl);
 
+        //parse data into a useable form (title, description, authors, subjects, publishers,
+        //publish date, publish places, series, book cover link, physical format, edition name,
+        // ISBN-13, ISBN-10, associated works, and number of pages)
         let description = "No description provided.";
         if (resultJson.description) {
             if (typeof resultJson.description === "object") {
@@ -219,10 +225,10 @@ const bookInformation = async (req, res) => {
             subjects: resultJson.subjects || "No subjects provided.",
             publishers: resultJson.publishers || "No publisher provided.",
             publishDate: resultJson.publish_date || "No publish date provided.",
+            publishPlaces: resultJson.publish_places || "No publish places provided.",
             series: resultJson.series || "No series provided.",
             bookCover: bookCover,
             physicalFormat: resultJson.physical_format || "No format provided.",
-            publishPlaces: resultJson.publish_places || "No publish places provided.",
             editionName: resultJson.edition_name || "No edition name provided.",
             isbn13: resultJson.isbn_13 || "No ISBN-13 number provided.",
             isbn10: resultJson.isbn_10 || "No ISBN-10 number provided.",
@@ -237,17 +243,10 @@ const bookInformation = async (req, res) => {
     }
 }
 
-//Search OpenLibrary for a book. The query can be a book title, ISBN-10, ISBN-13, or OLID
-//It fetches 10 books per request. the page query parameter specifies the page of the
+//Search OpenLibrary for a work. The query can be a book title, ISBN-10, ISBN-13, or OLID
+//It fetches 10 works per request. the page query parameter specifies the page of the
 //search result. For example, page 1 has books 0 through 9, page 2 has books 10 through 19,
-//etc.
-
-/* 
-TODO Flow:
-Search for WORKS (not books) -> list of books with non-edition specific info (e.g., title, authors, subjects, median num pages, edition count)
-Click on work -> get list of editions (books) with specific information (e.g., title, authors, publishers publish dates, publish locations, num pages, edition, )
-*/
-
+//etc. If there is no page number provided, it defaults to page 1.
 const searchBooks = async (req, res) => {
     try {
         let searchQuery = req.params.query;
@@ -257,10 +256,12 @@ const searchBooks = async (req, res) => {
         //API call for getting 10 works from the search
         let workUrl = `https://openlibrary.org/search.json?q=${searchQuery}&limit=${limit}&page=${page}`;
 
-        //parse data into JSON object
+        //Make request and get JSON object containing information
         let resultJson = await getJsonFromReq(workUrl);
 
-        //parse the data into a more usable format
+        //parse data into a useable form (array of titles, subtitles, authors, subjects, first sentences,
+        //book cover links, first published years, median page numbers, edition numbers, edition IDs,
+        //average ratings, total ratings numbers, and ratings breakdowns)
         let booksResult = [];
         for (let i = 0; i < resultJson.docs.length; i++) {
             let currentDoc = resultJson.docs[i];
@@ -275,6 +276,9 @@ const searchBooks = async (req, res) => {
                 bookCover = `https://covers.openlibrary.org/b/id/${currentDoc.cover_i}-S.jpg`;
             }
 
+            //ratingsBreakdown contains how many 1-star, 2-star, 3-star, 4-star, and 5-star ratings
+            //their are for the work. 1-star ratings are stored at index 0, 2-star ratings are stored
+            //at index 1, etc.
             let numRatingsTotal = "No ratings count provided.";
             let ratingsBreakdown = "No ratings breakdown provided.";
             if (currentDoc.ratings_count) {
@@ -309,7 +313,22 @@ const searchBooks = async (req, res) => {
         if (booksResult.length === 0) {
             booksResult.push("No results.");
         }
-        res.send(booksResult);
+
+        //include search result data with useful statistics, including the number of total
+        //search results found, the index of the first result on the current page, and the
+        //number of search results on the current page.
+        let numOnPage = Math.min(limit, resultJson.numFound - resultJson.start);
+        if (numOnPage < 0) {
+            numOnPage = 0;
+        }
+        let resultInfo = {
+            numFound: resultJson.numFound,
+            indexOfFirstResult: resultJson.start,
+            numOnPage: numOnPage,
+            results: booksResult
+        }
+
+        res.send(resultInfo);
     } catch (error) {
         console.log(`Error: ${error}`);
         res.status(400).json({ error: { status: 400, message: error } });

--- a/server/controllers/booksApi.js
+++ b/server/controllers/booksApi.js
@@ -244,7 +244,7 @@ const bookInformation = async (req, res) => {
 }
 
 //Search OpenLibrary for a work. The query can be a book title, ISBN-10, ISBN-13, or OLID
-//It fetches 10 works per request. the page query parameter specifies the page of the
+//It fetches 10 works per request. The page query parameter specifies the page of the
 //search result. For example, page 1 has books 0 through 9, page 2 has books 10 through 19,
 //etc. If there is no page number provided, it defaults to page 1.
 const searchBooks = async (req, res) => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,6 +23,7 @@
         "mongodb": "^6.1.0",
         "mongoose": "^7.6.2",
         "nodemailer": "^6.9.6",
+        "supertest": "^6.3.3",
         "uuid": "^9.0.1"
       }
     },
@@ -2433,6 +2434,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/supertest": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
+      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "8.1.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,7 +23,6 @@
         "mongodb": "^6.1.0",
         "mongoose": "^7.6.2",
         "nodemailer": "^6.9.6",
-        "supertest": "^6.3.3",
         "uuid": "^9.0.1"
       }
     },
@@ -2434,18 +2433,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/supertest": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
-      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
-      "dependencies": {
-        "methods": "^1.1.2",
-        "superagent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">=6.4.0"
-      }
     },
     "node_modules/supports-color": {
       "version": "8.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -33,7 +33,6 @@
     "mongodb": "^6.1.0",
     "mongoose": "^7.6.2",
     "nodemailer": "^6.9.6",
-    "supertest": "^6.3.3",
     "uuid": "^9.0.1"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -4,8 +4,9 @@
   "description": "A web application that attempts to facilitate the collection of books",
   "main": "server.js",
   "scripts": {
-    "test": "npx mocha unitTests/**/*.js --recursive --exit --timeout 10000",
-    "start": "node server.js"
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "npx mocha unitTests/**/*.js --recursive --exit --timeout 10000"
   },
   "repository": {
     "type": "git",
@@ -32,6 +33,7 @@
     "mongodb": "^6.1.0",
     "mongoose": "^7.6.2",
     "nodemailer": "^6.9.6",
+    "supertest": "^6.3.3",
     "uuid": "^9.0.1"
   }
 }

--- a/server/routes/booksApiRoutes.js
+++ b/server/routes/booksApiRoutes.js
@@ -12,10 +12,12 @@ const router = express.Router();
 //Get featured books.
 router.get('/featured', verifyToken, booksApiController.featured);
 
-//Get work information from a specified Open Library ID (OLID). The ID MUST end with a 'W'.
+//Get work information from a specified Open Library ID (OLID).
+//The ID MUST end with a 'W'.
 router.get('/works/:id', verifyToken, booksApiController.workInformation);
 
-//Get book information from a specified Open Library ID (OLID). The ID MUST end with an 'M'.
+//Get book information from a specified Open Library ID (OLID).
+//The ID MUST end with an 'M'.
 router.get('/books/:id', verifyToken, booksApiController.bookInformation);
 
 //Search OpenLibrary for a book. The query can be a book title, ISBN-10, ISBN-13, or OLID.

--- a/server/routes/booksApiRoutes.js
+++ b/server/routes/booksApiRoutes.js
@@ -9,10 +9,17 @@ const router = express.Router();
 
 //Routes
 
-//get featured books
+//Get featured books.
 router.get('/featured', verifyToken, booksApiController.featured);
 
-//get book information from a specified Open Library ID (OLID)
-router.get('/information/:id', verifyToken, booksApiController.workInformation);
+//Get work information from a specified Open Library ID (OLID). The ID MUST end with a 'W'.
+router.get('/works/:id', verifyToken, booksApiController.workInformation);
+
+//Get book information from a specified Open Library ID (OLID). The ID MUST end with an 'M'.
+router.get('/books/:id', verifyToken, booksApiController.bookInformation);
+
+//Search OpenLibrary for a book. The query can be a book title, ISBN-10, ISBN-13, or OLID.
+router.get('/searchBooks/:query', verifyToken, booksApiController.searchBooks);
+router.get('/searchBooks/:query/:page', verifyToken, booksApiController.searchBooks);
 
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -22,7 +22,9 @@ app.use('/static', express.static(path.join(__dirname, 'node_modules')));
 
 /*Access and host the routes needed for authentication*/
 app.use('/api', authRoutes);
-app.use('/api/books', booksApiRoutes);
+
+//Access and host the routes needed for book and OpenLibrary data
+app.use('/api/booksApi', booksApiRoutes);
 
 //This is the 404 Route. THIS MUST REMAIN LAST IT CATCHES ALL OTHER GET REQUESTS 
 app.get('*', function (req, res) {

--- a/server/unitTests/booksApiTest.js
+++ b/server/unitTests/booksApiTest.js
@@ -8,15 +8,20 @@ chai.use(chaiHTTP);
 
 let access_token, refresh_token, removeID, emailToken;
 
+//Make random account credentials
 const randomEmail = Math.random().toString(36).substring(8) + "@gmail.com";
 const randomPass = Math.random().toString(36).substring(0).repeat(2);
 console.log(randomEmail + " | " + randomPass);
 
+//Wait for server to connect to database
 before(function (done) {
     this.timeout(4000);
     setTimeout(done, 3000);
 });
 
+//Register an account so that we can get the verification token to access the API routes
+//Although this account will be stored in the database, it will be deleted at the end of the
+//tests
 describe('POST /api/register', () => {
     after(async () => {
         const user = await User.findOne({ email: randomEmail });
@@ -47,6 +52,8 @@ describe('POST /api/register', () => {
     });
 });
 
+//Book API route tests:
+
 describe('GET /api/booksApi/featured', function () {
     it('should get array of 10 works', function (done) {
         chai.request(server)
@@ -64,16 +71,17 @@ describe('GET /api/booksApi/featured', function () {
                 }
                 done();
             });
-    })
-})
+    });
+});
 
-describe('GET /api/works/OL27448W', function () {
+describe('GET /api/booksApi/works/OL27448W', function () {
     it('should get information about the specified work (The Lord of the Rings)', function (done) {
         chai.request(server)
             .get('/api/booksApi/works/OL27448W')
             .set({ "Authorization": `Bearer ${access_token}` })
             .end((err, res) => {
                 expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
                 expect(res.body).to.have.property('title');
                 expect(res.body).to.have.property('authors');
                 expect(res.body).to.have.property('firstPublishDate');
@@ -84,10 +92,10 @@ describe('GET /api/works/OL27448W', function () {
                 expect(res.body).to.have.property('firstSentence');
                 done();
             });
-    })
-})
+    });
+});
 
-describe('GET /api/works/OL5237526M', function () {
+describe('GET /api/booksApi/works/OL5237526M', function () {
     it('should return an error due to invalid ID (ID of a book, not a work)', function (done) {
         chai.request(server)
             .get('/api/booksApi/works/OL5237526M')
@@ -96,27 +104,28 @@ describe('GET /api/works/OL5237526M', function () {
                 expect(res).to.have.status(400);
                 done();
             });
-    })
-})
+    });
+});
 
-describe('GET /api/books/OL26451897M', function () {
+describe('GET /api/booksApi/books/OL26451897M', function () {
     it('should get information about the specified book (The Fellowship of the Ring)', function (done) {
         chai.request(server)
             .get('/api/booksApi/books/OL26451897M')
             .set({ "Authorization": `Bearer ${access_token}` })
             .end((err, res) => {
                 expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
                 expect(res.body).to.have.property('title');
                 expect(res.body).to.have.property('description');
                 expect(res.body).to.have.property('authors');
                 expect(res.body).to.have.property('subjects');
                 expect(res.body).to.have.property('publishers');
                 expect(res.body).to.have.property('publishDate');
+                expect(res.body).to.have.property('publishPlaces');
                 expect(res.body).to.have.property('series');
                 expect(res.body).to.have.property('bookCover')
                     .to.match(/https:\/\/covers.openlibrary.org\/b\/id\/\d+-S.jpg/);
                 expect(res.body).to.have.property('physicalFormat');
-                expect(res.body).to.have.property('publishPlaces');
                 expect(res.body).to.have.property('editionName');
                 expect(res.body).to.have.property('isbn13');
                 expect(res.body).to.have.property('isbn10');
@@ -127,10 +136,10 @@ describe('GET /api/books/OL26451897M', function () {
                 expect(res.body).to.have.property('numPages');
                 done();
             });
-    })
-})
+    });
+});
 
-describe('GET /api/books/OL27448W', function () {
+describe('GET /api/booksApi/books/OL27448W', function () {
     it('should return an error due to invalid ID (ID of a work, not a book)', function (done) {
         chai.request(server)
             .get('/api/booksApi/books/OL27448W')
@@ -139,37 +148,160 @@ describe('GET /api/books/OL27448W', function () {
                 expect(res).to.have.status(400);
                 done();
             });
-    })
-})
+    });
+});
 
-describe('GET /api/searchBooks/lord+of+the+rings', function () {
-    it('should return information about top 10 search results (works)', function (done) {
+describe('GET /api/booksApi/searchBooks/lord+of+the+rings', function () {
+    it('should return information about the top 10 (at most) search results (works)', function (done) {
         chai.request(server)
             .get('/api/booksApi/searchBooks/lord+of+the+rings')
             .set({ "Authorization": `Bearer ${access_token}` })
             .end((err, res) => {
                 expect(res).to.have.status(200);
-                expect(res.body).to.be.an('array').that.has.lengthOf(10);
-                for (let i = 0; i < res.body.length; i++) {
-                    expect(res.body[i]).to.have.property('title');
-                    expect(res.body[i]).to.have.property('subtitle');
-                    expect(res.body[i]).to.have.property('authors');
-                    expect(res.body[i]).to.have.property('subjects');
-                    expect(res.body[i]).to.have.property('firstSentence');
-                    expect(res.body[i]).to.have.property('bookCover');
-                    expect(res.body[i]).to.have.property('firstPublishYear');
-                    expect(res.body[i]).to.have.property('medianNumPages');
-                    expect(res.body[i]).to.have.property('numEditions');
-                    expect(res.body[i]).to.have.property('editionIds');
-                    expect(res.body[i]).to.have.property('ratingsAverage');
-                    expect(res.body[i]).to.have.property('numRatingsTotal');
-                    expect(res.body[i]).to.have.property('ratingsBreakdown');
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('numFound');
+                expect(res.body).to.have.property('indexOfFirstResult').to.equal(0);
+                expect(res.body).to.have.property('numOnPage').to.equal(10);
+                expect(res.body).to.have.property('results').to.be.an('array');
+                for (let i = 0; i < res.body.results.length; i++) {
+                    expect(res.body.results[i]).to.have.property('title');
+                    expect(res.body.results[i]).to.have.property('subtitle');
+                    expect(res.body.results[i]).to.have.property('authors');
+                    expect(res.body.results[i]).to.have.property('subjects');
+                    expect(res.body.results[i]).to.have.property('firstSentence');
+                    expect(res.body.results[i]).to.have.property('bookCover');
+                    expect(res.body.results[i]).to.have.property('firstPublishYear');
+                    expect(res.body.results[i]).to.have.property('medianNumPages');
+                    expect(res.body.results[i]).to.have.property('numEditions');
+                    expect(res.body.results[i]).to.have.property('editionIds');
+                    expect(res.body.results[i]).to.have.property('ratingsAverage');
+                    expect(res.body.results[i]).to.have.property('numRatingsTotal');
+                    expect(res.body.results[i]).to.have.property('ratingsBreakdown');
                 }
-                expect(res.body[0].ratingsBreakdown).to.be.an('array').that.has.lengthOf(5);
+                expect(res.body.results[0].ratingsBreakdown).to.be.an('array').that.has.lengthOf(5);
                 done();
             });
-    })
-})
+    });
+});
+
+describe('GET /api/booksApi/searchBooks/OL27448W', function () {
+    it('should return information about the top 9 search results ' +
+        'for the given OLID (as there are only 9 results)', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/searchBooks/OL27448W')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('numFound').to.equal(9);
+                expect(res.body).to.have.property('indexOfFirstResult').to.equal(0);
+                expect(res.body).to.have.property('numOnPage').to.equal(9);
+                expect(res.body).to.have.property('results').to.be.an('array');
+                for (let i = 0; i < res.body.results.length; i++) {
+                    expect(res.body.results[i]).to.have.property('title');
+                    expect(res.body.results[i]).to.have.property('subtitle');
+                    expect(res.body.results[i]).to.have.property('authors');
+                    expect(res.body.results[i]).to.have.property('subjects');
+                    expect(res.body.results[i]).to.have.property('firstSentence');
+                    expect(res.body.results[i]).to.have.property('bookCover');
+                    expect(res.body.results[i]).to.have.property('firstPublishYear');
+                    expect(res.body.results[i]).to.have.property('medianNumPages');
+                    expect(res.body.results[i]).to.have.property('numEditions');
+                    expect(res.body.results[i]).to.have.property('editionIds');
+                    expect(res.body.results[i]).to.have.property('ratingsAverage');
+                    expect(res.body.results[i]).to.have.property('numRatingsTotal');
+                    expect(res.body.results[i]).to.have.property('ratingsBreakdown');
+                }
+                done();
+            });
+    });
+});
+
+describe('GET /api/booksApi/searchBooks/GZPGJaA6nGLihNsn', function () {
+    it('should return a results array with the message "No results." (as no results are found)', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/searchBooks/GZPGJaA6nGLihNsn')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('numFound').to.equal(0);
+                expect(res.body).to.have.property('indexOfFirstResult').to.equal(0);
+                expect(res.body).to.have.property('numOnPage').to.equal(0);
+                expect(res.body).to.have.property('results').to.be.an('array').that.has.lengthOf(1);
+                expect(res.body.results[0]).to.equal('No results.');
+                done();
+            });
+    });
+});
+
+describe('GET /api/booksApi/searchBooks/lord+of+the+rings/2', function () {
+    it('should return information about the top 11-20 search results (works)', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/searchBooks/lord+of+the+rings/2')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('numFound');
+                expect(res.body).to.have.property('indexOfFirstResult').to.equal(10);
+                expect(res.body).to.have.property('numOnPage').to.equal(10);
+                expect(res.body).to.have.property('results').to.be.an('array');
+                for (let i = 0; i < res.body.results.length; i++) {
+                    expect(res.body.results[i]).to.have.property('title');
+                    expect(res.body.results[i]).to.have.property('subtitle');
+                    expect(res.body.results[i]).to.have.property('authors');
+                    expect(res.body.results[i]).to.have.property('subjects');
+                    expect(res.body.results[i]).to.have.property('firstSentence');
+                    expect(res.body.results[i]).to.have.property('bookCover');
+                    expect(res.body.results[i]).to.have.property('firstPublishYear');
+                    expect(res.body.results[i]).to.have.property('medianNumPages');
+                    expect(res.body.results[i]).to.have.property('numEditions');
+                    expect(res.body.results[i]).to.have.property('editionIds');
+                    expect(res.body.results[i]).to.have.property('ratingsAverage');
+                    expect(res.body.results[i]).to.have.property('numRatingsTotal');
+                    expect(res.body.results[i]).to.have.property('ratingsBreakdown');
+                }
+                done();
+            });
+    });
+});
+
+describe('GET /api/booksApi/searchBooks/OL27448W/2', function () {
+    it('should return a results array with the message "No results." (as no results are on page 2)', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/searchBooks/OL27448W/2')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('numFound').to.equal(9);
+                expect(res.body).to.have.property('indexOfFirstResult').to.equal(10);
+                expect(res.body).to.have.property('numOnPage').to.equal(0);
+                expect(res.body).to.have.property('results').to.be.an('array').that.has.lengthOf(1);
+                expect(res.body.results[0]).to.equal('No results.');
+                done();
+            });
+    });
+});
+
+describe('GET /api/booksApi/searchBooks/GZPGJaA6nGLihNsn/3', function () {
+    it('should return a results array with the message "No results." (as no results are found)', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/searchBooks/GZPGJaA6nGLihNsn/3')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.property('numFound').to.equal(0);
+                expect(res.body).to.have.property('indexOfFirstResult').to.equal(20);
+                expect(res.body).to.have.property('numOnPage').to.equal(0);
+                expect(res.body).to.have.property('results').to.be.an('array').that.has.lengthOf(1);
+                expect(res.body.results[0]).to.equal('No results.');
+                done();
+            });
+    });
+});
 
 after(async () => {
     try {

--- a/server/unitTests/booksApiTest.js
+++ b/server/unitTests/booksApiTest.js
@@ -1,0 +1,181 @@
+const chai = require('chai');
+const chaiHTTP = require('chai-http');
+const server = require('../server.js');
+const User = require('../models/user');
+
+const expect = chai.expect;
+chai.use(chaiHTTP);
+
+let access_token, refresh_token, removeID, emailToken;
+
+const randomEmail = Math.random().toString(36).substring(8) + "@gmail.com";
+const randomPass = Math.random().toString(36).substring(0).repeat(2);
+console.log(randomEmail + " | " + randomPass);
+
+before(function (done) {
+    this.timeout(4000);
+    setTimeout(done, 3000);
+});
+
+describe('POST /api/register', () => {
+    after(async () => {
+        const user = await User.findOne({ email: randomEmail });
+        emailToken = user.emailToken;
+        console.log(emailToken);
+    });
+
+    it('should return a registeration success response', (done) => {
+        chai.request(server)
+            .post('/api/register')
+            .send({ "email": randomEmail, "password": randomPass })
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.have.property('success');
+                expect(res.body.success).to.have.property('status').to.equal(200);
+                expect(res.body.success).to.have.property('message').to.equal('REGISTER_SUCCESS');
+
+                expect(res.body.success).to.have.property('accessToken');
+                expect(res.body.success).to.have.property('refreshToken');
+                expect(res.body.success).to.have.property('user');
+                expect(res.body.success.user).to.have.property('id');
+
+                access_token = res.body.success.accessToken;
+                refresh_token = res.body.success.refreshToken;
+                id = res.body.success.id;
+                done();
+            });
+    });
+});
+
+describe('GET /api/booksApi/featured', function () {
+    it('should get array of 10 works', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/featured')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('array').that.has.lengthOf(10)
+                for (let i = 0; i < res.body.length; i++) {
+                    expect(res.body[i]).to.have.property('olid')
+                        .to.match(/^OL\d+W$/);
+                    expect(res.body[i]).to.have.property('title');
+                    expect(res.body[i]).to.have.property('bookCover')
+                        .to.match(/https:\/\/covers.openlibrary.org\/b\/id\/\d+-S.jpg/);
+                }
+                done();
+            });
+    })
+})
+
+describe('GET /api/works/OL27448W', function () {
+    it('should get information about the specified work (The Lord of the Rings)', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/works/OL27448W')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.have.property('title');
+                expect(res.body).to.have.property('authors');
+                expect(res.body).to.have.property('firstPublishDate');
+                expect(res.body).to.have.property('description');
+                expect(res.body).to.have.property('bookCover')
+                    .to.match(/https:\/\/covers.openlibrary.org\/b\/id\/\d+-S.jpg/);
+                expect(res.body).to.have.property('subjects');
+                expect(res.body).to.have.property('firstSentence');
+                done();
+            });
+    })
+})
+
+describe('GET /api/works/OL5237526M', function () {
+    it('should return an error due to invalid ID (ID of a book, not a work)', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/works/OL5237526M')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(400);
+                done();
+            });
+    })
+})
+
+describe('GET /api/books/OL26451897M', function () {
+    it('should get information about the specified book (The Fellowship of the Ring)', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/books/OL26451897M')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.have.property('title');
+                expect(res.body).to.have.property('description');
+                expect(res.body).to.have.property('authors');
+                expect(res.body).to.have.property('subjects');
+                expect(res.body).to.have.property('publishers');
+                expect(res.body).to.have.property('publishDate');
+                expect(res.body).to.have.property('series');
+                expect(res.body).to.have.property('bookCover')
+                    .to.match(/https:\/\/covers.openlibrary.org\/b\/id\/\d+-S.jpg/);
+                expect(res.body).to.have.property('physicalFormat');
+                expect(res.body).to.have.property('publishPlaces');
+                expect(res.body).to.have.property('editionName');
+                expect(res.body).to.have.property('isbn13');
+                expect(res.body).to.have.property('isbn10');
+                expect(res.body).to.have.property('works');
+                for (let i = 0; i < res.body.works.length; i++) {
+                    expect(res.body.works[i]).to.match(/^OL\d+W$/);
+                }
+                expect(res.body).to.have.property('numPages');
+                done();
+            });
+    })
+})
+
+describe('GET /api/books/OL27448W', function () {
+    it('should return an error due to invalid ID (ID of a work, not a book)', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/books/OL27448W')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(400);
+                done();
+            });
+    })
+})
+
+describe('GET /api/searchBooks/lord+of+the+rings', function () {
+    it('should return information about top 10 search results (works)', function (done) {
+        chai.request(server)
+            .get('/api/booksApi/searchBooks/lord+of+the+rings')
+            .set({ "Authorization": `Bearer ${access_token}` })
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('array').that.has.lengthOf(10);
+                for (let i = 0; i < res.body.length; i++) {
+                    expect(res.body[i]).to.have.property('title');
+                    expect(res.body[i]).to.have.property('subtitle');
+                    expect(res.body[i]).to.have.property('authors');
+                    expect(res.body[i]).to.have.property('subjects');
+                    expect(res.body[i]).to.have.property('firstSentence');
+                    expect(res.body[i]).to.have.property('bookCover');
+                    expect(res.body[i]).to.have.property('firstPublishYear');
+                    expect(res.body[i]).to.have.property('medianNumPages');
+                    expect(res.body[i]).to.have.property('numEditions');
+                    expect(res.body[i]).to.have.property('editionIds');
+                    expect(res.body[i]).to.have.property('ratingsAverage');
+                    expect(res.body[i]).to.have.property('numRatingsTotal');
+                    expect(res.body[i]).to.have.property('ratingsBreakdown');
+                }
+                expect(res.body[0].ratingsBreakdown).to.be.an('array').that.has.lengthOf(5);
+                done();
+            });
+    })
+})
+
+after(async () => {
+    try {
+        await User.deleteOne({ id: removeID });
+        console.log("data deleted");
+    } catch (err) {
+        console.error(err);
+    }
+});


### PR DESCRIPTION
## Main Changes
- Refactored existing route URLS:
  - All book API sub-routes are under the parent route `/api/booksApi`
  - Work information route is now `/api/booksApi/works/:id`
- Added two new sub-routes:
  - `/books/:id`
    - Gets the book information from a specified Open Library ID (OLID)
    - The ID MUST end with an 'M'
  - `/searchBooks/:query` and `/searchBooks/:query/:page`
    - Searches OpenLibrary for a book with a given book title, ISBN-10, ISBN-13, or OLID
    - Fetches 10 works per page
    - The page query parameter specifies the page of the search result.
- Added unit testing for all book API routes and controllers in file server/unitTests/booksApiTest.js

## Other Changes
- Changed the scripts in the server's package.json
  - `npm start` now runs `node server.js`
  - `npm run dev` now runs `nodemon server.js`