### PR TITLE
fix that uses the correct route name and adds headers to the call

### DIFF
--- a/LibraryFrontEnd/src/app/trending-book.service.ts
+++ b/LibraryFrontEnd/src/app/trending-book.service.ts
@@ -1,15 +1,22 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class TrendingBookService {
-  private apiUrl = 'http://localhost:4000/api/books/featured';
+  private apiUrl = environment.apiurl;
 
   constructor(private http: HttpClient) { }
 
   getTrendingBooks() {
-    return this.http.get(this.apiUrl);
+    const authToken = localStorage.getItem("jwt-auth-token");
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${authToken}`,
+    });
+
+    return this.http.get(`${this.apiUrl}/booksApi/featured`, { headers });
   }
 }


### PR DESCRIPTION
This pr fixes the featured book front end.
it now includes the auth tokens in the header for the call.
Also uses the new route name booksApi rather than books